### PR TITLE
Fix the tag of the quay.io container image

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: governance-policy-status-sync
       containers:
         - name: governance-policy-status-sync
-          image: quay.io/open-cluster-management/governance-policy-status-sync:latest-dev
+          image: quay.io/open-cluster-management/governance-policy-status-sync:latest
           command:
             - governance-policy-status-sync
           args:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -153,7 +153,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-status-sync
-        image: quay.io/open-cluster-management/governance-policy-status-sync:latest-dev
+        image: quay.io/open-cluster-management/governance-policy-status-sync:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
The Deployment manifest in `deploy/operator.yaml` was referencing the
incorrect and old tag. This should be using the `latest` tag instead.