### PR TITLE
[release-2.4] Fix CheckAddonPodFunc for leaseUpdater

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -163,7 +163,8 @@ func main() {
 				generatedClient,
 				"policy-controller",
 				operatorNs,
-				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app in (policy-framework,policy-config-policy)"),
+				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app=policy-framework"),
+				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app=policy-config-policy"),
 			)
 			go leaseUpdater.Start(ctx)
 		}


### PR DESCRIPTION
Need to use two separate `CheckAddonPodFunc`s to check policy-framework and config-policy-controller pod

For: https://github.com/open-cluster-management/backlog/issues/17607

Signed-off-by: Yu Cao <ycao@redhat.com>