### PR TITLE
Change addon lease name, remove old checks

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,13 +216,9 @@ func main() {
 			log.Info("Starting lease controller to report status")
 			leaseUpdater := lease.NewLeaseUpdater(
 				generatedClient,
-				"policy-controller",
+				"governance-policy-framework",
 				operatorNs,
 				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app=policy-framework"),
-				// this additional CheckAddonPodFunc is temporary until the
-				// addon framework independently verifies the config-policy-controller via its lease
-				// see https://github.com/stolostron/backlog/issues/11508
-				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app=policy-config-policy"),
 			).WithHubLeaseConfig(hubCfg, namespace)
 			go leaseUpdater.Start(ctx)
 		}


### PR DESCRIPTION
The new policy addon controller splits the previous "policy-controller"
addon into separate "config-policy-controller" and "governance-policy-
framework" addons. Each of those addons can manage their own lease, and
this controller no longer needs to check on the health of the config
policy controller.

Refs:
 - https://github.com/stolostron/backlog/issues/19521
 - https://github.com/stolostron/backlog/issues/20013
 - https://github.com/stolostron/backlog/issues/11508

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>