### PR TITLE
Fix label selector in addon lease health check

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         name: governance-policy-status-sync
-        app: policy-framework
+        app: governance-policy-framework
     spec:
       securityContext:
         runAsNonRoot: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -135,7 +135,7 @@ spec:
   template:
     metadata:
       labels:
-        app: policy-framework
+        app: governance-policy-framework
         name: governance-policy-status-sync
     spec:
       containers:

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func main() {
 				generatedClient,
 				"governance-policy-framework",
 				operatorNs,
-				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app=policy-framework"),
+				lease.CheckAddonPodFunc(generatedClient.CoreV1(), operatorNs, "app=governance-policy-framework"),
 			).WithHubLeaseConfig(hubCfg, namespace)
 			go leaseUpdater.Start(ctx)
 		}


### PR DESCRIPTION
The pod is deployed with label "governance-policy-framework" in the
addon chart. This updates that label in this repo's deployment YAML, as
well as in the health check for the addon lease.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>