### PR TITLE
Configure logging with utility package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GIT_HOST ?= github.com/stolostron
 
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
-export PATH=$(shell echo $$PATH):$(PWD)/bin
+export PATH := $(PWD)/bin:$(PATH)
 
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -24,6 +24,8 @@ spec:
           args:
             - "--hub-cluster-configfile=/var/run/klusterlet/kubeconfig"
             - "--enable-lease=true"
+            - "--log-level=2"
+            - "--v=0"
           imagePullPolicy: Always
           volumeMounts:
             - name: klusterlet-config

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -142,6 +142,8 @@ spec:
       - args:
         - --hub-cluster-configfile=/var/run/klusterlet/kubeconfig
         - --enable-lease=true
+        - --log-level=2
+        - --v=0
         command:
         - governance-policy-status-sync
         env:

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,12 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stolostron/go-log-utils v0.1.0
 	github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.40.1
 	open-cluster-management.io/addon-framework v0.2.0
 	sigs.k8s.io/controller-runtime v0.11.1
 )
@@ -72,7 +73,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.3 // indirect
 	k8s.io/apiserver v0.23.3 // indirect
 	k8s.io/component-base v0.23.3 // indirect
-	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	open-cluster-management.io/api v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1132,6 +1132,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stolostron/go-log-utils v0.1.0 h1:YRi84JogWKHCfrif46m/4rep+ucsc80c9667FzaBbTA=
+github.com/stolostron/go-log-utils v0.1.0/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
 github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
 github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38 h1:a3mDbBUE0eVXdzv0IIsz6/48F7Ru6LxwPduryJU7UXQ=
 github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38/go.mod h1:8lcjUP24z9gIZ1nCydZyOxIqz6CpVDtVt5KPAlsi+tY=

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/stolostron/governance-policy-status-sync/test/utils"
 )


### PR DESCRIPTION
Our logs will be configurable through `--log-level`, klog level (used by controller-runtime, for example) will be configurable through `--v`.
