### PR TITLE
Remove namespace permissions

### DIFF
--- a/controllers/sync/policy_status_sync.go
+++ b/controllers/sync/policy_status_sync.go
@@ -62,7 +62,7 @@ type PolicyReconciler struct {
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events;namespaces,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // This is required for the status lease for the addon framework
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -52,7 +52,6 @@ rules:
   - ""
   resources:
   - events
-  - namespaces
   verbs:
   - create
   - delete

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -10,7 +10,6 @@ rules:
   - ""
   resources:
   - events
-  - namespaces
   verbs:
   - create
   - delete


### PR DESCRIPTION
These permissions are no longer required since the cluster namespace is
not managed by this controller.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>