### PR TITLE
[release-2.6] Break ties between event timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ any of the Kustomize files, you may regenerate `deploy/operator.yaml` by running
 - The `governance-policy-status-sync` is part of the `open-cluster-management` community. For more information, visit: [open-cluster-management.io](https://open-cluster-management.io).
 
 <!---
-Date: April/29/2022
+Date: 10/21/2022
 -->

--- a/controllers/sync/policy_status_sync.go
+++ b/controllers/sync/policy_status_sync.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -170,7 +171,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 	// filter events to current policy instance and build map
-	eventForPolicyMap := make(map[string]*[]policiesv1.ComplianceHistory)
+	eventForPolicyMap := make(map[string]*[]historyEvent)
 	// panic if regexp invalid
 	rgx := regexp.MustCompile(`(?i)^policy:\s*([A-Za-z0-9.-]+)\s*\/([A-Za-z0-9.-]+)`)
 	for _, event := range eventList.Items {
@@ -179,14 +180,18 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		if event.InvolvedObject.Kind == policiesv1.Kind && event.InvolvedObject.APIVersion == policiesv1APIVersion &&
 			event.InvolvedObject.Name == instance.GetName() && reason != "" {
 			templateName := rgx.FindStringSubmatch(event.Reason)[2]
-			eventHistory := policiesv1.ComplianceHistory{
-				LastTimestamp: event.LastTimestamp,
-				Message:       strings.TrimSpace(strings.TrimPrefix(event.Message, "(combined from similar events):")),
-				EventName:     event.GetName(),
+			eventHistory := historyEvent{
+				ComplianceHistory: policiesv1.ComplianceHistory{
+					LastTimestamp: event.LastTimestamp,
+					Message: strings.TrimSpace(strings.TrimPrefix(
+						event.Message, "(combined from similar events):")),
+					EventName: event.GetName(),
+				},
+				eventTime: *event.EventTime.DeepCopy(),
 			}
 
 			if eventForPolicyMap[templateName] == nil {
-				eventForPolicyMap[templateName] = &[]policiesv1.ComplianceHistory{}
+				eventForPolicyMap[templateName] = &[]historyEvent{}
 			}
 
 			templateEvents := append(*eventForPolicyMap[templateName], eventHistory)
@@ -235,7 +240,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			}
 		}
 
-		history := []policiesv1.ComplianceHistory{}
+		history := []historyEvent{}
 		if eventForPolicyMap[tName] != nil {
 			history = *eventForPolicyMap[tName]
 		}
@@ -251,20 +256,55 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 					break
 				}
 			}
-			// doesn't exists, append to history
+			// doesn't exist, append to history
 			if !exists {
-				history = append(history, ech)
+				history = append(history, historyEvent{ComplianceHistory: ech})
 			}
 		}
-		// sort by lasttimestamp
+		// sort by lasttimestamp, break ties with EventTime (if present) or EventName
 		sort.Slice(history, func(i, j int) bool {
-			return history[i].LastTimestamp.Time.After(history[j].LastTimestamp.Time)
+			if history[i].LastTimestamp.Equal(&history[j].LastTimestamp) {
+				if !history[i].eventTime.IsZero() && !history[j].eventTime.IsZero() {
+					reqLogger.V(2).Info("Event timestamp collision, order determined by EventTime",
+						"event1Name", history[i].EventName, "event2Name", history[j].EventName)
+
+					return !history[i].eventTime.Before(&history[j].eventTime)
+				}
+				// Timestamps are the same: attempt to use the event name.
+				// Conventionally (in client-go), the event name has a hexadecimal
+				// nanosecond timestamp as a suffix after a period.
+				iNameParts := strings.Split(history[i].EventName, ".")
+				jNameParts := strings.Split(history[j].EventName, ".")
+				errMsg := "Unable to interpret hexadecimal timestamp in event name, " +
+					"can't guarantee ordering of events in this status"
+
+				iNanos, err := strconv.ParseInt(iNameParts[len(iNameParts)-1], 16, 64)
+				if err != nil {
+					reqLogger.Error(err, errMsg, "eventName", history[i].EventName)
+
+					return false
+				}
+
+				jNanos, err := strconv.ParseInt(jNameParts[len(jNameParts)-1], 16, 64)
+				if err != nil {
+					reqLogger.Error(err, errMsg, "eventName", history[j].EventName)
+
+					return false
+				}
+
+				reqLogger.V(2).Info("Event timestamp collision, order determined by hex timestamp in name",
+					"event1Name", history[i].EventName, "event2Name", history[j].EventName)
+
+				return iNanos > jNanos
+			}
+
+			return !history[i].LastTimestamp.Time.Before(history[j].LastTimestamp.Time)
 		})
 		// remove duplicates
 		newHistory := []policiesv1.ComplianceHistory{}
 
 		for historyIndex := 0; historyIndex < len(history); historyIndex++ {
-			newHistory = append(newHistory, history[historyIndex])
+			newHistory = append(newHistory, history[historyIndex].ComplianceHistory)
 
 			for j := historyIndex; j < len(history); j++ {
 				if history[historyIndex].EventName == history[j].EventName &&
@@ -363,4 +403,9 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	reqLogger.Info("Reconciling complete")
 
 	return reconcile.Result{}, nil
+}
+
+type historyEvent struct {
+	policiesv1.ComplianceHistory
+	eventTime metav1.MicroTime
 }

--- a/test/e2e/case1_mutation_recovery_test.go
+++ b/test/e2e/case1_mutation_recovery_test.go
@@ -186,18 +186,10 @@ var _ = Describe("Test mutation recovery", func() {
 			"Normal",
 			"policy: managed/case1-test-policy-trustedcontainerpolicy",
 			"Compliant; No violation detected")
-		By("Checking if policy status is compliant")
-		Eventually(func() interface{} {
-			managedPlc = utils.GetWithTimeout(
-				clientManagedDynamic,
-				gvrPolicy,
-				case1PolicyName,
-				testNamespace,
-				true,
-				defaultTimeoutSeconds)
 
-			return getCompliant(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		By("Checking if policy status is compliant")
+		Eventually(checkCompliance(case1PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("Compliant"))
 
 		By("Update status to NonCompliant")
 		Eventually(
@@ -216,18 +208,11 @@ var _ = Describe("Test mutation recovery", func() {
 			1,
 		).Should(BeNil())
 		Expect(getCompliant(managedPlc)).To(Equal("NonCompliant"))
-		By("Checking if policy status was recovered to compliant")
-		Eventually(func() interface{} {
-			managedPlc = utils.GetWithTimeout(
-				clientManagedDynamic,
-				gvrPolicy,
-				case1PolicyName,
-				testNamespace,
-				true,
-				defaultTimeoutSeconds)
 
-			return getCompliant(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		By("Checking if policy status was recovered to compliant")
+		Eventually(checkCompliance(case1PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("Compliant"))
+
 		By("clean up all events")
 		_, err := utils.KubectlWithOutput("delete", "events", "-n", testNamespace, "--all",
 			"--kubeconfig=../../kubeconfig_managed")

--- a/test/e2e/case7_ts_collision_test.go
+++ b/test/e2e/case7_ts_collision_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+const (
+	case7PolicyYaml    string = "../resources/case7_ts_collision/case7-policy.yaml"
+	case7PolicyName    string = "default.case7-test-policy"
+	case7Event1        string = "../resources/case7_ts_collision/case7-event-one.yaml"
+	case7Event2        string = "../resources/case7_ts_collision/case7-event-two.yaml"
+	case7Event3        string = "../resources/case7_ts_collision/case7-event-three.yaml"
+	case7Event4        string = "../resources/case7_ts_collision/case7-event-four.yaml"
+	case7Event5        string = "../resources/case7_ts_collision/case7-event-five.yaml"
+	case7Event6        string = "../resources/case7_ts_collision/case7-event-six.yaml"
+	case7hubconfig     string = "--kubeconfig=../../kubeconfig_hub"
+	case7managedconfig string = "--kubeconfig=../../kubeconfig_managed"
+)
+
+var _ = Describe("Test event sorting by name when timestamps collide", Ordered, func() {
+	It("Creates the policy and one event, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7Event1, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(checkCompliance(case7PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("Compliant"))
+		Consistently(checkCompliance(case7PolicyName), "15s", 1).
+			Should(Equal("Compliant"))
+	})
+
+	It("Creates a second event with the same timestamp, and shows noncompliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event2, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(checkCompliance(case7PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("NonCompliant"))
+		Consistently(checkCompliance(case7PolicyName), "15s", 1).
+			Should(Equal("NonCompliant"))
+	})
+
+	It("Creates a third with the same timestamp, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event3, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(checkCompliance(case7PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("Compliant"))
+		Consistently(checkCompliance(case7PolicyName), "15s", 1).
+			Should(Equal("Compliant"))
+	})
+
+	AfterAll(func() {
+		_, err := utils.KubectlWithOutput("delete", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7Event1, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7Event2, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7Event3, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+	})
+})
+
+var _ = Describe("Test event sorting by eventtime when timestamps collide", Ordered, func() {
+	It("Creates the policy and one event, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7Event4, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(checkCompliance(case7PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("Compliant"))
+		Consistently(checkCompliance(case7PolicyName), "15s", 1).
+			Should(Equal("Compliant"))
+	})
+
+	It("Creates a second event with the same timestamp, and shows noncompliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event5, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(checkCompliance(case7PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("NonCompliant"))
+		Consistently(checkCompliance(case7PolicyName), "15s", 1).
+			Should(Equal("NonCompliant"))
+	})
+
+	It("Creates a third with the same timestamp, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event6, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(checkCompliance(case7PolicyName), defaultTimeoutSeconds, 1).
+			Should(Equal("Compliant"))
+		Consistently(checkCompliance(case7PolicyName), "15s", 1).
+			Should(Equal("Compliant"))
+	})
+
+	AfterAll(func() {
+		_, err := utils.KubectlWithOutput("delete", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7Event4, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7Event5, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+		_, err = utils.KubectlWithOutput("delete", "-f", case7Event6, "-n", testNamespace, case7managedconfig)
+		Expect(err).Should(BeNil())
+	})
+})

--- a/test/resources/case7_ts_collision/case7-event-five.yaml
+++ b/test/resources/case7_ts_collision/case7-event-five.yaml
@@ -1,0 +1,24 @@
+action: "filler"
+apiVersion: v1
+count: 1
+eventTime: "2022-10-03T14:40:47.222222Z"
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: NonCompliant; violation - a problem sandwich
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  name: default.case7-test-policy.b.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: "filler"
+reportingInstance: "filler"
+source:
+  component: configuration-policy-controller
+type: Warning

--- a/test/resources/case7_ts_collision/case7-event-four.yaml
+++ b/test/resources/case7_ts_collision/case7-event-four.yaml
@@ -1,0 +1,24 @@
+action: "filler"
+apiVersion: v1
+count: 1
+eventTime: "2022-10-03T14:40:47.111111Z"
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this is the oldest event
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  name: default.case7-test-policy.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: "filler"
+reportingInstance: "filler"
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-one.yaml
+++ b/test/resources/case7_ts_collision/case7-event-one.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+count: 1
+eventTime: null
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this is the oldest event
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-six.yaml
+++ b/test/resources/case7_ts_collision/case7-event-six.yaml
@@ -1,0 +1,25 @@
+action: "filler"
+apiVersion: v1
+count: 1
+eventTime: "2022-10-03T14:40:47.333333Z"
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this should be the most recent
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.c.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: "filler"
+reportingInstance: "filler"
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-three.yaml
+++ b/test/resources/case7_ts_collision/case7-event-three.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+count: 1
+eventTime: null
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this should be the most recent
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.171a96193dea32f8
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-two.yaml
+++ b/test/resources/case7_ts_collision/case7-event-two.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+count: 1
+eventTime: null
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: NonCompliant; violation - a problem sandwich
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.171a96193dea32f4
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: configuration-policy-controller
+type: Warning

--- a/test/resources/case7_ts_collision/case7-policy.yaml
+++ b/test/resources/case7_ts_collision/case7-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: default.case7-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: default.case7-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case7-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+


### PR DESCRIPTION
In some cases (it seems to be becoming more common), policy events may be batched together by policy controllers, and then sent in the same second. When this happens, status-sync could not accurately sort them. Since the controller will not re-send compliant events without other changes, this resulted in the policy and the template disagreeing on the compliance state.

Compliance events (by convention) suffix the name with a hexadecimal encoding of the time they were created, which is used here to break timestamp ties.

Cherrypicked from these upstream commits:
- df31d40aa58630b7757d177dced3212911143008
- 955ba8556a71740e94e13a61af5be707738a8b37
- be110ec7886a0972e6084ec63ee7783e146abe34
- 499ee07d8ba074e1f4469f18aff0d22c7e949474
- 55257b07b2960b58942a5997a06bc05da72f6b56

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>